### PR TITLE
Fix full_name fallback logic and tests

### DIFF
--- a/allusgov/tests/test_utils.py
+++ b/allusgov/tests/test_utils.py
@@ -1,4 +1,31 @@
-"""Sample unit test module using pytest-describe and expecter."""
-# pylint: disable=redefined-outer-name,unused-variable,expression-not-assigned,singleton-comparison
+"""Tests for utility helpers."""
 
-# from allusgov import utils
+from allusgov.utils.utils import full_name
+
+
+class FakeNode:
+    """Minimal node implementation for testing ``full_name``."""
+
+    def __init__(self, attrs=None):
+        self._attrs = attrs or {}
+
+    def get_attr(self, source_name):
+        return self._attrs.get(source_name)
+
+    def describe(self, exclude_prefix="_", exclude_attributes=None):
+        for source, data in self._attrs.items():
+            if exclude_attributes:
+                data = {
+                    k: v for k, v in data.items() if k not in exclude_attributes
+                }
+            yield source, data
+
+
+def test_full_name_prefers_requested_source():
+    node = FakeNode({"a": {"name": "Alpha"}, "b": {"name": "Beta"}})
+    assert full_name(node, "b") == "Beta"
+
+
+def test_full_name_falls_back_to_any_source():
+    node = FakeNode({"a": {"name": "Alpha"}})
+    assert full_name(node, "missing") == "Alpha"

--- a/allusgov/utils/utils.py
+++ b/allusgov/utils/utils.py
@@ -15,9 +15,11 @@ def full_name(org: Optional[Node], source_name: str) -> str:
     attrs = org.get_attr(source_name)
     if attrs and "name" in attrs:
         return attrs["name"]
-    # Otherwise, return the first name attribute found form any source.
-    attrs = org.describe(exclude_prefix="_", exclude_attributes=["name"])
-    return attrs[0][1]["name"]
+    # Otherwise, return the first name attribute found from any source.
+    for _source, values in org.describe(exclude_prefix="_"):
+        if "name" in values:
+            return values["name"]
+    return ""
 
 
 def spider_uri_params(params, spider):


### PR DESCRIPTION
## Summary
- fix `full_name` when primary source is missing
- add unit tests for util helper

## Testing
- `make test` *(fails: could not connect to pypi.org to install dependencies)*