### PR TITLE
Fix command injection risk in open helper

### DIFF
--- a/bin/open
+++ b/bin/open
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
+import shlex
+import subprocess
 import sys
 
 
@@ -15,7 +16,8 @@ COMMANDS = {
 
 def run(path):
     command = COMMANDS.get(sys.platform, "open")
-    os.system(command + ' ' + path)
+    args = shlex.split(command) + [path]
+    subprocess.run(args, check=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- secure `bin/open` by using `subprocess.run` instead of `os.system`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'log')*